### PR TITLE
fix: workaround for broken EpochLength event handling

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -35,6 +35,7 @@ async function deployContracts(ganachePort) {
         PROPOSAL_TIME: '0',
         PARENT_BLOCK_INTERVAL: '0',
         ADVANCE_BLOCK: '0',
+        EPOCH_LENGTH: '2',
         EVENTS_DELAY: '1'
       };
       const cwd = process.cwd();


### PR DESCRIPTION
By setting correct Epoch Length at deployment time we are evading the problem