### PR TITLE
fix: missing update for leap-core to support CAS-ready getProof

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ethers": "^4.0.33",
     "ganache-cli": "6.6.0",
     "jsbi-utils": "^1.0.0",
-    "leap-core": "^0.33.0",
+    "leap-core": "^0.35.0",
     "leap-provider": "^1.0.0",
     "nyan-js": "^1.1.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -461,10 +461,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leap-core@^0.33.0:
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.33.0.tgz#5ee36f4eb46746a2edd3af8a03bc17ba0e644bcd"
-  integrity sha512-eMT4E8oXycDk9yBmqXVmUCStdRH9EE0tJyVcAA+N7HGjAvvc/zcNdoSGkfqwHpa88elNCdNb7MRQIRPH4FMIsA==
+leap-core@^0.35.0:
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.35.0.tgz#89d5a470a37a355a843647840a3f6ffdd5a99f79"
+  integrity sha512-q8VKCXtbFVCUEkAbQp4YE+8aZ8lxXc9zOQGxwZ2M/6eRysXVzloywcD7/T2zJG+nvaw4xg7+kGxgaDEiaZrORA==
   dependencies:
     "@types/web3" "^1.0.18"
     ethereumjs-util "6.0.0"


### PR DESCRIPTION
Forgotten change for https://github.com/leapdao/integration-tests/pull/50