### PR TITLE
feat: allow to run tests on warm env

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 A set of scripts to set up a local Leap network or/and run integration tests against it.
 
 * [Setup](#setup)
-    * [Install dependencies](#install-dependencies)
-    * [Fetch relevant Leap subprojects](#fetch-relevant-leap-subprojects)
+  * [Install dependencies](#install-dependencies)
+  * [Fetch relevant Leap subprojects](#fetch-relevant-leap-subprojects)
 * [Usage](#usage)
-    * [Start local environment (for development or testing)](#start-local-environment-for-development-or-testing)
-      * [Start flavoured Leap Network (Recipies)](#start-flavoured-leap-network-recipies)
-      * [Using with Docker](#using-with-docker)
-    * [Run integration tests](#run-integration-tests)
-    * [Writing your own tests](#writing-your-own-tests)
+  * [Start local environment (for development or testing)](#start-local-environment-for-development-or-testing)
+    * [Start flavoured Leap Network (Recipies)](#start-flavoured-leap-network-recipies)
+    * [Using with Docker](#using-with-docker)
+  * [Run integration tests](#run-integration-tests)
+  * [Writing your own tests](#writing-your-own-tests)
 
 ## Setup
 
@@ -49,8 +49,8 @@ This will generate a build folder in the project and fetch the repos and build t
 
 Local environment consist of the following parts:
 
-- Ganache as a root chain with Leap contracts deployed
-- one or multiple leap-node instances with JSON RPC
+* Ganache as a root chain with Leap contracts deployed
+* one or multiple leap-node instances with JSON RPC
 
 To start local env use the following command:
 
@@ -60,12 +60,12 @@ yarn start [--onlyRoot] [<recipe>]
 
 Optional arguments:
 
-- `--onlyRoot` — start only the root chain with plasma contracts. To start leap-node later on use `yarn start` in another terminal.
-- `<recipe>` — apply one of the recipies to the network. See below.
+* `--onlyRoot` — start only the root chain with plasma contracts. To start leap-node later on use `yarn start` in another terminal.
+* `<recipe>` — apply one of the recipies to the network. See below.
 
 Ganache setup logs and leap-node's logs are in the `out/` folder.
 
-#### Start flavoured Leap Network (Recipies)
+#### Start flavoured Leap Network (recipes)
 
 In `tests/recipies` you can see possible recipies to run against the local network. Each recipe prepares the environment for a particular purpose — sets up required tokens, makes deposits etc.
 
@@ -103,12 +103,12 @@ yarn test [<testName>]
 
 Optional arguments:
 
-- `<testName>` — name of the test to run (e.g. `8_breeding`). If not specified, all the tests will be executed.
+* `<testName>` — name of the test to run (e.g. `8_breeding`). If not specified, all the tests will be executed.
 
 This command
 
-- starts a local leap network or connects to the existing one
-- runs the tests from the `tests` directory
+* starts a local leap network or connects to the existing one
+* runs the tests from the `tests` directory
 
 The tests will write logs to a folder ./out/.
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,30 @@
-# integration-tests
+# Leap sandbox
 
 ![image](https://user-images.githubusercontent.com/163447/49596266-3c6e7b80-f97a-11e8-8c63-7cb5108a3ea9.png)
 
-## 1. Setup
+A set of scripts to set up a local Leap network or/and run integration tests against it.
+
+* [Setup](#setup)
+    * [Install dependencies](#install-dependencies)
+    * [Fetch relevant Leap subprojects](#fetch-relevant-leap-subprojects)
+* [Usage](#usage)
+    * [Start local environment (for development or testing)](#start-local-environment-for-development-or-testing)
+      * [Start flavoured Leap Network (Recipies)](#start-flavoured-leap-network-recipies)
+      * [Using with Docker](#using-with-docker)
+    * [Run integration tests](#run-integration-tests)
+    * [Writing your own tests](#writing-your-own-tests)
+
+## Setup
+
+### Install dependencies
 
 ```sh
 yarn
 ```
 
-## 2. Build
+### Fetch relevant Leap subprojects
 
-The integration tests will be run against a version of the node and contracts software. In configs/build, you can specify what version you would like to use. It can be either a local folder or a remote github repository. Examples:
+Sandbox needs a version of the leap-node and leap-contracts to run. In configs/build, you can specify what version you would like to use. It can be either a local folder or a remote github repository. Examples:
 
 ```sh
 # To run against master
@@ -29,62 +43,29 @@ yarn build
 
 This will generate a build folder in the project and fetch the repos and build them. Yarn logs of the build are available in build/logs.
 
-## 3. Run tests
+## Usage
 
-After you have built the projects, you can start the tests. Some parameters can be configured in configs/run. When you are happy with the congiguration, run:
+### Start local environment (for development or testing)
 
-```sh
-yarn test
-```
+Local environment consist of the following parts:
 
-This will:
+- Ganache as a root chain with Leap contracts deployed
+- one or multiple leap-node instances with JSON RPC
 
-1. launch a ganache network
-2. deploy the contracts
-3. start the configured number of nodes
-4. perform setup tasks
-5. run all the tests in the tests directory
-
-The tests will write logs to a folder ./out/, where you can look for information about the test run (deployment log, ganache network log and a log for each of the nodes).
-
-## Writing your own tests
-
-To add a test, create a file in the tests directory that looks like this:
-
-```js
-module.exports = async function(contracts, nodes, accounts, web3) {
-  // Your tests go here
-}
-```
-
-The function parameters are objects you will receive to perform you test. Here is the describtion:
-
-```js
-// contracts are web3.eth.Contract objects 
-contracts = {token, bridge, operator, exitHandler}
-
-// nodes are Node objects (defined in src/nodeClient) representing the running nodes
-nodes = [node0, node1...]
-
-// accounts are simple objects containing the address and private key
-accounts = [{addr, privKey}, {addr, privKey}...]
-// also note: accounts[1] is the admin of all the proxys
-
-// web3 is just Web3 contected to the ganache network
-web3 = Web3
-```
-
-## Start local environment for development
-
-### Start default / vanilla Leap network
+To start local env use the following command:
 
 ```sh
-yarn start
+yarn start [--onlyRoot] [<recipe>]
 ```
 
-This will launch a local Leap Network for you: Ganache as a root chain with Leap contracts deployed and leap-node with JSON RPC.
+Optional arguments:
 
-### Start flavoured Leap Network
+- `--onlyRoot` — start only the root chain with plasma contracts. To start leap-node later on use `yarn start` in another terminal.
+- `<recipe>` — apply one of the recipies to the network. See below.
+
+Ganache setup logs and leap-node's logs are in the `out/` folder.
+
+#### Start flavoured Leap Network (Recipies)
 
 In `tests/recipies` you can see possible recipies to run against the local network. Each recipe prepares the environment for a particular purpose — sets up required tokens, makes deposits etc.
 
@@ -98,7 +79,7 @@ E.g. `yarn start planetA` to start a local network for Planet A project.
 
 Alternatively, you can start vanilla leap network and then apply a recipe with `yarn apply planetA`.
 
-### Using with Docker
+#### Using with Docker
 
 Start vanilla network:
 
@@ -113,3 +94,51 @@ docker exec leap-env node applyRecipe planetA
 ```
 
 `yarn start <recipe>` should also work for applying recipes to dockerized network, given you have the repo working copy.
+
+### Run integration tests
+
+```sh
+yarn test [<testName>]
+```
+
+Optional arguments:
+
+- `<testName>` — name of the test to run (e.g. `8_breeding`). If not specified, all the tests will be executed.
+
+This command
+
+- starts a local leap network or connects to the existing one
+- runs the tests from the `tests` directory
+
+The tests will write logs to a folder ./out/.
+
+### Writing your own tests
+
+To add a test, create a file in the tests directory that looks like this:
+
+```js
+module.exports = async function({ contracts, nodes, accounts, wallet, plasmaWallet }) {
+  // Your tests go here
+}
+```
+
+The function parameters are objects you will receive to perform you test. Here is the description:
+
+```js
+// contracts are web3.eth.Contract objects
+contracts = {token, bridge, operator, exitHandler}
+
+// nodes are Node objects (defined in src/nodeClient) representing the running nodes
+nodes = [node0, node1...]
+
+// accounts are simple objects containing the address and private key
+accounts = [{addr, privKey}, {addr, privKey}...]
+// also note: accounts[1] is the admin of all the proxys
+
+// wallet is an ethers.Wallet conected to the root chain /ganache with accounts imported.
+wallet = ethers.Wallet
+
+// plasmaWallet is an ethers.Wallet conected to the plasma chain with accounts imported.
+plasmaWallet = ethers.Wallet
+
+```

--- a/src/commands/applyRecipe.js
+++ b/src/commands/applyRecipe.js
@@ -1,8 +1,8 @@
-const getEnv = require('../getEnv');
+const startOrConnectToNetwork = require('../run');
 
 async function run(name) {
   console.log('Applying recipe: ', name);
-  const { contracts, nodes, accounts, wallet, plasmaWallet } = await getEnv();
+  const { contracts, nodes, accounts, wallet, plasmaWallet } = await startOrConnectToNetwork();
 
   await require(`../../tests/recipies/${name}`)(contracts, nodes, accounts, wallet, plasmaWallet);
   process.exit(0);

--- a/src/commands/applyRecipe.js
+++ b/src/commands/applyRecipe.js
@@ -16,4 +16,4 @@ function onException (e) {
 process.on('uncaughtException', onException);
 process.on('unhandledRejection', onException);
 
-run(process.argv[2]);
+run(process.argv.filter(a => a.startsWith('--'))[2]);

--- a/src/commands/applyRecipe.js
+++ b/src/commands/applyRecipe.js
@@ -16,4 +16,4 @@ function onException (e) {
 process.on('uncaughtException', onException);
 process.on('unhandledRejection', onException);
 
-run(process.argv.filter(a => a.startsWith('--'))[2]);
+run(process.argv.filter(a => !a.startsWith('--'))[2]);

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -15,4 +15,4 @@ function onException (e) {
 process.on('uncaughtException', onException);
 process.on('unhandledRejection', onException);
 
-run(process.argv.filter(a => a.startsWith('--'))[2]);
+run(process.argv.filter(a => !a.startsWith('--'))[2]);

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -15,4 +15,4 @@ function onException (e) {
 process.on('uncaughtException', onException);
 process.on('unhandledRejection', onException);
 
-run(process.argv[2]);
+run(process.argv.filter(a => a.startsWith('--'))[2]);

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -7,8 +7,9 @@ require('chai').should();
 
 const getTests = async () => {
   const testPath = path.join(__dirname, '../../tests');
-  if (process.argv[2]) {
-    return [process.argv[2]];
+  const singleTest = process.argv.filter(a => a.startsWith('--'))[2];
+  if (singleTest) {
+    return [singleTest];
   };
   const tests = fs
     .readdirSync(testPath)

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -7,7 +7,7 @@ require('chai').should();
 
 const getTests = async () => {
   const testPath = path.join(__dirname, '../../tests');
-  const singleTest = process.argv.filter(a => a.startsWith('--'))[2];
+  const singleTest = process.argv.filter(a => !a.startsWith('--'))[2];
   if (singleTest) {
     return [singleTest];
   };

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -1,8 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const nyan = require('nyan-js');
-const startNetwork = require('../run');
-const getEnv = require('../getEnv');
+const startOrConnectToNetwork = require('../run');
 
 require('chai').should();
 
@@ -20,15 +19,7 @@ const getTests = async () => {
 };
 
 async function run() {
-  let env;
-
-  try {
-    env = await getEnv();
-    console.log('Using existing local env');
-  } catch (e) {
-    env = await startNetwork();
-  }
-
+  const env = await startOrConnectToNetwork();
   const tests = await getTests();
   for (const test of tests) {
     console.log('Running: ', test);

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -1,7 +1,8 @@
 const path = require('path');
 const fs = require('fs');
-const startNetwork = require('../run');
 const nyan = require('nyan-js');
+const startNetwork = require('../run');
+const getEnv = require('../getEnv');
 
 require('chai').should();
 
@@ -19,7 +20,14 @@ const getTests = async () => {
 };
 
 async function run() {
-  const env = await startNetwork();
+  let env;
+
+  try {
+    env = await getEnv();
+    console.log('Using existing local env');
+  } catch (e) {
+    env = await startNetwork();
+  }
 
   const tests = await getTests();
   for (const test of tests) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const ethers = require('ethers');
 const { Tx } = require('leap-core');
 
 const range = (s, e) =>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -99,4 +99,29 @@ const waitForChange = async (func, expected, timeout) => {
   assert.equal(actual, expected);
 };
 
-module.exports = { mine, sleep, formatHostname, makeTransfer, makeTransferUxto, advanceBlocks, updateLine, waitForChange };
+const advanceUntilTokenBalanceChange = async (
+  addr, tokenAddr, prevBalance, rootWallet, plasmaWallet, msg
+) => {
+  const token = new ethers.Contract(tokenAddr, erc20abi, plasmaWallet);
+  let currentBalance;
+  
+  const frames = ['🌕','🌖','🌗','🌘','🌑','🌒','🌓','🌔'];
+  let i = 0;
+  do {
+    i++;
+    await advanceBlocks(1, rootWallet);
+    await sleep(100);
+    currentBalance = await token.balanceOf(addr);
+    process.stdout.write(
+      `\r${msg} `+ 
+      `${currentBalance.toString() !== String(prevBalance) ? '✅' : frames[i % 8]} `
+    );
+  } while(currentBalance.toString() === String(prevBalance))
+  return currentBalance;
+};
+
+module.exports = { 
+  mine, sleep, formatHostname,
+  makeTransfer, makeTransferUxto,
+  advanceBlocks, updateLine,
+  waitForChange, advanceUntilTokenBalanceChange };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const ethers = require('ethers');
 const { Tx } = require('leap-core');
+const erc20abi = require('./erc20abi');
 
 const range = (s, e) =>
   Array.from(new Array(e - s + 1), (_, i) => i + s);

--- a/src/nodeClient.js
+++ b/src/nodeClient.js
@@ -63,25 +63,6 @@ class Node extends LeapProvider {
     }
   }
 
-  async advanceUntilTokenBalanceChange(addr, tokenAddr, prevBalance, rootWallet, plasmaWallet, msg) {
-    const token = new ethers.Contract(tokenAddr, erc20abi, plasmaWallet);
-    let currentBalance;
-    
-    const frames = ['🌕','🌖','🌗','🌘','🌑','🌒','🌓','🌔'];
-    let i = 0;
-    do {
-      i++;
-      await advanceBlocks(1, rootWallet);
-      await sleep(100);
-      currentBalance = await token.balanceOf(addr);
-      process.stdout.write(
-        `\r${msg} `+ 
-        `${currentBalance.toString() !== String(prevBalance) ? '✅' : frames[i % 8]} `
-      );
-    } while(currentBalance.toString() === String(prevBalance))
-    return currentBalance;
-  }
-
   getRpcUrl() {
     return `http://${this.hostname}:${this.port}`;
   }

--- a/src/nodeClient.js
+++ b/src/nodeClient.js
@@ -1,7 +1,5 @@
-const ethers = require('ethers');
 const LeapProvider = require('leap-provider');
 
-const erc20abi = require('./erc20abi');
 const { formatHostname, advanceBlocks, sleep } = require('./helpers');
 
 const flatValues = map => 

--- a/src/run.js
+++ b/src/run.js
@@ -186,7 +186,15 @@ module.exports = async () => {
   const { accounts, wallet, contracts, ganache } = await connectOrStartRootNetwork();;
 
   if (!onlyRootChain) {
-    plasmaEnv = await connectOrStartPlasmaNetwork({ contracts, wallet });
+    plasmaEnv = await connectOrStartPlasmaNetwork({ contracts, accounts, wallet });
+
+    const mintAndDeposit = require('../tests/actions/mintAndDeposit');
+
+    await mintAndDeposit(
+      accounts[0], '200000000000000000000', accounts[0].addr, 
+      contracts.token, 0, contracts.exitHandler, wallet, plasmaEnv.plasmaWallet
+    );
+  
   }
 
   console.log(`\n Root chain RPC (ganache): ${ganache}`);

--- a/src/run.js
+++ b/src/run.js
@@ -3,7 +3,7 @@ const spawn = require('child_process').spawn;
 const ethers = require('ethers');
 const ganache = require('ganache-cli');
 
-const getEnv = require('./getEnv');
+const { getRootEnv, getPlasmaEnv, getContracts } = require('./getEnv');
 
 const mnemonic = require('./mnemonic');
 
@@ -101,14 +101,9 @@ async function spawnNode(rpcPort, args, env, logOutput) {
   );
 }
 
-module.exports = async () => {
-  const ganachePort = parseInt(process.env['ganache_port']) || 8545;
+const spawnNodes = async () => {
   // seems like only one connection from the same source addr can connect to the same tendermint instance
   const numNodes = parseInt(process.env['num_nodes']) || 2;
-
-  await setupGanache(ganachePort, mnemonic);
-  await deployContracts(ganachePort);
-  
   const nodes = [];
 
   const generatedConfigPath = `${process.cwd()}/build/contracts/build/nodeFiles/generatedConfig.json`;
@@ -142,22 +137,55 @@ module.exports = async () => {
     console.log(`Starting node ${i + 1} of ${numNodes} Logs: ./out/node-${i + 1}.log`);
     nodes.push(await spawnNode(rpcPort, args, env, logOutput));
   }
+  return nodes;
+};
 
-  const config = {
-    nodes: nodes.map(n => n.toString()),
-    ganache: `http://localhost:${ganachePort}`
-  };
+const appendToConfig = (appendix) => {
+  const config = Object.assign(
+    JSON.parse(fs.readFileSync('./process.json', { flag: 'a+' }).toString() || '{}'),
+    appendix,
+  );
 
   fs.writeFileSync('./process.json', JSON.stringify(config, null, 2));
+}
 
-  const { contracts, accounts, wallet, plasmaWallet } = await getEnv();
+const connectOrStartRootNetwork = async () => {
+  try {
+    const rootEnv = await getRootEnv();
+    console.log('Reusing existing Ganache instance');
+    return rootEnv;
+  } catch (e) {
+    const ganachePort = parseInt(process.env['ganache_port']) || 8545;
+    await setupGanache(ganachePort, mnemonic);
+    await deployContracts(ganachePort);
+    appendToConfig({ ganache: `http://localhost:${ganachePort}` });
+    return getRootEnv();
+  }
+};
 
+const connectOrStartPlasmaNetwork = async () => {
+  try {
+    const plasmaEnv = await getPlasmaEnv();
+    console.log('Reusing existing leap-node instance');
+    return plasmaEnv;
+  } catch (e) {
+    const nodes = await spawnNodes();
+    appendToConfig({ nodes: nodes.map(n => n.toString()) });
+    return getPlasmaEnv();
+  }
+};
+
+module.exports = async () => {
+  const { accounts, wallet, ganache } = await connectOrStartRootNetwork();
+  const { nodes, plasmaWallet, networkConfig } = await connectOrStartPlasmaNetwork();
+  const contracts = await getContracts(networkConfig, wallet);
+  
   await setup(contracts, nodes, accounts, wallet, plasmaWallet);
 
   console.log('Started');
 
   console.log(`\n Leap JSON RPC: ${nodes[0].getRpcUrl()}`);
-  console.log(`Root chain RPC: http://localhost:${ganachePort}\n`);
+  console.log(`Root chain RPC: ${ganache}\n`);
   console.log('Priv key: ', accounts[0].privKey);
 
   return { contracts, nodes, accounts, wallet, plasmaWallet };

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,21 +1,14 @@
 const ethers = require('ethers');
 const { mine } = require('./helpers');
-const mintAndDeposit = require('../tests/actions/mintAndDeposit');
 
-module.exports = async function(contracts, nodes, accounts, wallet, plasmaWallet) {
-  const alice = accounts[0].addr;
-
-  let data = contracts.token.interface.functions.addMinter.encode([alice]);
-  await mine(contracts.governance.propose(contracts.token.address, data, { gasLimit: 2000000 }));
-  await mine(contracts.governance.finalize());
-  await mine(contracts.token.mint(alice, '500000000000000000000'));
-  await mine(contracts.token.approve(contracts.exitHandler.address, '500000000000000000000'));
-  await mine(contracts.token.approve(contracts.operator.address, '500000000000000000000'));
-
+module.exports.setupValidators = async ({ contracts, nodes, wallet }) => {
+  const msg = `\r${' '.repeat(100)}\rSetting up nodes...`;
   for (let i = 0; i < nodes.length; i++) {
+    
     const validatorInfo = await nodes[i].getValidatorInfo();
     const overloadedSlotId = `${contracts.operator.address}00000000000000000000000${i}`;
 
+    process.stdout.write(`${msg} set slot ${i}`);
     await mine(
       contracts.governance.setSlot(
         overloadedSlotId,
@@ -25,6 +18,7 @@ module.exports = async function(contracts, nodes, accounts, wallet, plasmaWallet
       )
     );
 
+    process.stdout.write(`${msg} fund validator ${i}`);
     await mine(
       wallet.sendTransaction({
         to: validatorInfo.ethAddress,
@@ -33,6 +27,7 @@ module.exports = async function(contracts, nodes, accounts, wallet, plasmaWallet
     );
   }
 
+  process.stdout.write(`${msg} set epoch length`);
   data = contracts.operator.interface.functions.setEpochLength.encode([nodes.length]);
   await mine(
     contracts.governance.propose(
@@ -43,6 +38,27 @@ module.exports = async function(contracts, nodes, accounts, wallet, plasmaWallet
     )
   );
 
+  process.stdout.write(`${msg} finalize`);
+  await mine(contracts.governance.finalize({ gasLimit: 2000000 }));
+  process.stdout.write(`${msg} done\n`);
+};
+
+module.exports.setupPlasma = async ({ contracts, accounts }) => {
+  const alice = accounts[0].addr;
+
+  const msg = `\r${' '.repeat(100)}\rSetting up plasma contracts...`;
+  process.stdout.write(`${msg} add minter`);
+  let data = contracts.token.interface.functions.addMinter.encode([alice]);
+  await mine(contracts.governance.propose(contracts.token.address, data, { gasLimit: 2000000 }));
+  await mine(contracts.governance.finalize());
+  process.stdout.write(`${msg} mint token`);
+  await mine(contracts.token.mint(alice, '500000000000000000000'));
+  process.stdout.write(`${msg} set allowance for exitHandler`);
+  await mine(contracts.token.approve(contracts.exitHandler.address, '500000000000000000000'));
+  process.stdout.write(`${msg} set allowance for operator`);
+  await mine(contracts.token.approve(contracts.operator.address, '500000000000000000000'));
+
+  process.stdout.write(`${msg} set exit duration`);
   data = contracts.exitHandler.interface.functions.setExitDuration.encode([0]);
   await mine(
     contracts.governance.propose(
@@ -52,10 +68,13 @@ module.exports = async function(contracts, nodes, accounts, wallet, plasmaWallet
       }
     )
   );
+  process.stdout.write(`${msg} finalize`);
   await mine(contracts.governance.finalize({ gasLimit: 2000000 }));
+  process.stdout.write(`${msg} done\n`);
 
-  await mintAndDeposit(
-    accounts[0], '200000000000000000000', alice, 
-    contracts.token, 0, contracts.exitHandler, nodes[0], wallet, plasmaWallet
-  );
+  // const mintAndDeposit = require('../tests/actions/mintAndDeposit');
+  // await mintAndDeposit(
+  //   accounts[0], '200000000000000000000', alice, 
+  //   contracts.token, 0, contracts.exitHandler, wallet, plasmaWallet
+  // );
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,7 +1,10 @@
 const ethers = require('ethers');
 const { mine } = require('./helpers');
+const mintAndDeposit = require('../tests/actions/mintAndDeposit');
 
-module.exports.setupValidators = async ({ contracts, nodes, wallet }) => {
+module.exports.setupValidators = async (
+  { contracts, nodes, wallet, accounts, plasmaWallet }
+) => {
   const msg = `\r${' '.repeat(100)}\rSetting up nodes...`;
   for (let i = 0; i < nodes.length; i++) {
     
@@ -41,6 +44,11 @@ module.exports.setupValidators = async ({ contracts, nodes, wallet }) => {
   process.stdout.write(`${msg} finalize`);
   await mine(contracts.governance.finalize({ gasLimit: 2000000 }));
   process.stdout.write(`${msg} done\n`);
+  
+  await mintAndDeposit(
+    accounts[0], '200000000000000000000', accounts[0].addr, 
+    contracts.token, 0, contracts.exitHandler, wallet, plasmaWallet
+  );
 };
 
 module.exports.setupPlasma = async ({ contracts, accounts }) => {
@@ -72,9 +80,4 @@ module.exports.setupPlasma = async ({ contracts, accounts }) => {
   await mine(contracts.governance.finalize({ gasLimit: 2000000 }));
   process.stdout.write(`${msg} done\n`);
 
-  // const mintAndDeposit = require('../tests/actions/mintAndDeposit');
-  // await mintAndDeposit(
-  //   accounts[0], '200000000000000000000', alice, 
-  //   contracts.token, 0, contracts.exitHandler, wallet, plasmaWallet
-  // );
 }

--- a/tests/1_depositTransferExit.js
+++ b/tests/1_depositTransferExit.js
@@ -26,7 +26,7 @@ module.exports = async function(env) {
     console.log("║3. Exit Alice and Bob                     ║");
     console.log("╚══════════════════════════════════════════╝");
 
-    await mintAndDeposit(accounts[2], amount, minter, contracts.token, 0, contracts.exitHandler, node, wallet, plasmaWallet);
+    await mintAndDeposit(accounts[2], amount, minter, contracts.token, 0, contracts.exitHandler, wallet, plasmaWallet);
 
     console.log('Making a few transfers..');
     for (let i = 0; i < 2; i++) {

--- a/tests/3_depositExitTransfer.js
+++ b/tests/3_depositExitTransfer.js
@@ -29,7 +29,7 @@ module.exports = async function(env) {
     console.log("║3. Try to transfer exited utxo            ║");
     console.log("╚══════════════════════════════════════════╝");
     
-    await mintAndDeposit(accounts[6], amount, minter, contracts.token, 0, contracts.exitHandler, node, wallet, plasmaWallet);
+    await mintAndDeposit(accounts[6], amount, minter, contracts.token, 0, contracts.exitHandler, wallet, plasmaWallet);
     
     await minePeriod(env);
     

--- a/tests/4_epochLengthExit.js
+++ b/tests/4_epochLengthExit.js
@@ -30,7 +30,7 @@ module.exports = async function(env) {
     console.log("║4. Exit Bob                               ║");
     console.log("╚══════════════════════════════════════════╝");
     
-    await mintAndDeposit(accounts[7], amount, minter, contracts.token, 0, contracts.exitHandler, node, wallet, plasmaWallet);
+    await mintAndDeposit(accounts[7], amount, minter, contracts.token, 0, contracts.exitHandler, wallet, plasmaWallet);
     
     log("------Transfer from Alice to Bob------");
     let txAmount = Math.round(amount/(2000))+ Math.round(100 * Math.random());

--- a/tests/actions/exitUnspent.js
+++ b/tests/actions/exitUnspent.js
@@ -5,7 +5,11 @@ const { bufferToHex } = require('ethereumjs-util');
 const { bi, equal, subtract } = require('jsbi-utils');
 const { assert } = require('chai');
 
-const { advanceBlocks, updateLine } = require('./../../src/helpers');
+const { 
+  advanceBlocks,
+  updateLine,
+  advanceUntilTokenBalanceChange,
+} = require('./../../src/helpers');
 
 const log = debug('exitUnspent');
 
@@ -142,7 +146,7 @@ module.exports = async function(env, addr, color) {
     const balanceAfter = await contracts.token.balanceOf(addr);
     log("Account mainnet balance: ", balanceAfter.toString());
     
-    const plasmaBalanceAfter = await node.advanceUntilTokenBalanceChange(
+    const plasmaBalanceAfter = await advanceUntilTokenBalanceChange(
       addr, contracts.token.address, plasmaBalanceBefore, wallet, plasmaWallet, 
       `${msg} waiting for balance change`
     );

--- a/tests/actions/mintAndDeposit.js
+++ b/tests/actions/mintAndDeposit.js
@@ -1,5 +1,5 @@
 const ethers = require('ethers');
-const { bi, add } = require('jsbi-utils');
+const { bi, add, greaterThan } = require('jsbi-utils');
 const { assert } = require('chai');
 
 const { mine, sleep, advanceUntilTokenBalanceChange } = require('../../src/helpers');
@@ -10,6 +10,10 @@ module.exports = async function(to, amount, minter, token, color, exitHandler, w
   const alice = to.addr;
   const aliceWallet = to.wallet;
   const oldPlasmaBalance = await plasmaToken.balanceOf(alice);
+
+  if (greaterThan(bi(oldPlasmaBalance), bi(0))) {
+    return;
+  }
 
   const msg = `\rMinting and depositing ${await token.symbol()}...`;
   process.stdout.write(`${msg} minting`);

--- a/tests/actions/mintAndDeposit.js
+++ b/tests/actions/mintAndDeposit.js
@@ -2,10 +2,10 @@ const ethers = require('ethers');
 const { bi, add } = require('jsbi-utils');
 const { assert } = require('chai');
 
-const { mine, sleep } = require('../../src/helpers');
+const { mine, sleep, advanceUntilTokenBalanceChange } = require('../../src/helpers');
 const erc20abi = require('../../src/erc20abi');
 
-module.exports = async function(to, amount, minter, token, color, exitHandler, node, wallet, plasmaWallet) {
+module.exports = async function(to, amount, minter, token, color, exitHandler, wallet, plasmaWallet) {
   const plasmaToken = new ethers.Contract(token.address, erc20abi, plasmaWallet);
   const alice = to.addr;
   const aliceWallet = to.wallet;
@@ -24,7 +24,7 @@ module.exports = async function(to, amount, minter, token, color, exitHandler, n
   await mine(exitHandler.connect(aliceWallet).depositBySender(amount, color, { gasLimit: 2000000 }));
   
   const balanceFinal = Number(await token.balanceOf(alice));
-  const currentPlasmaBalance = await node.advanceUntilTokenBalanceChange(
+  const currentPlasmaBalance = await advanceUntilTokenBalanceChange(
     alice, token.address, oldPlasmaBalance, wallet, plasmaWallet, 
     `${msg} waiting for deposit to be caught`
   );

--- a/tests/recipies/planetA.js
+++ b/tests/recipies/planetA.js
@@ -83,7 +83,7 @@ module.exports = async function(contracts, [node], accounts, wallet, plasmaWalle
   const co2Amount = ethers.utils.parseEther('1000').toString();
   await mintAndDeposit(
     accounts[0], co2Amount, minter, 
-    co2Token, co2Color, contracts.exitHandler, node, wallet, plasmaWallet
+    co2Token, co2Color, contracts.exitHandler, wallet, plasmaWallet
   );
 
   await advanceBlocks(6, wallet);
@@ -91,7 +91,7 @@ module.exports = async function(contracts, [node], accounts, wallet, plasmaWalle
   const goellarsAmount = ethers.utils.parseEther('200').toString();
   await mintAndDeposit(
     accounts[0], goellarsAmount, minter, 
-    goellarsToken, goellarsColor, contracts.exitHandler, node, wallet, plasmaWallet
+    goellarsToken, goellarsColor, contracts.exitHandler, wallet, plasmaWallet
   );
 
   airCode = replaceAll(airCode, "1231111111111111111111111111111111111123", co2Token.address);


### PR DESCRIPTION
Resolves #68 

- [x] run tests on warm env
- [x] start/restart a node on a warm env

See README in this PR for details


## Run tests on a warm env

1. Start a local env with `yarn start`
2. In a separate terminal run tests or a single test e.g. `yarn test 8_breeding`

## Run pre-warmed root chain

1. `yarn start --onlyRoot` starts only ganache with plasma contracts
2. In a separate terminal `yarn start` or `yarn test` will do the thing by starting only a leap-node